### PR TITLE
WIP: Multiple Calendar Management for multiple accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ Google Workspace (G Suite) APIs require OAuth2 authorization. Follow these steps
    [
      "openid",
      "https://mail.google.com/",
-     "https://www.googleapis.com/auth/calendar"
+     "https://www.googleapis.com/auth/calendar",
+     "https://www.googleapis.com/auth/userinfo.email"
    ]
 
 3. Then create a `.gauth.json` in your working directory:

--- a/gmail-api-openapi-spec.yaml
+++ b/gmail-api-openapi-spec.yaml
@@ -1,0 +1,1630 @@
+agger: "2.0"
+info:
+  title: Gmail
+  description: Access Gmail mailboxes including sending user email.
+  contact:
+    name: Google
+    url: https://google.com
+  version: v1
+host: www.googleapis.com
+basePath: /gmail/v1/users
+schemes:
+- http
+produces:
+- application/json
+consumes:
+- application/json
+paths:
+  /{userId}/drafts:
+    get:
+      summary: Get Drafts
+      description: Lists the drafts in the user's mailbox
+      operationId: gmail.users.drafts.list
+      parameters:
+      - in: query
+        name: includeSpamTrash
+        description: Include drafts from SPAM and TRASH in the results
+      - in: query
+        name: maxResults
+        description: Maximum number of drafts to return
+      - in: query
+        name: pageToken
+        description: Page token to retrieve a specific page of results in the list
+      - in: query
+        name: q
+        description: Only return draft messages matching the specified query
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Email
+    post:
+      summary: Update Draft
+      description: Creates a new draft with the DRAFT label
+      operationId: gmail.users.drafts.create
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Email
+  /{userId}/drafts/send:
+    post:
+      summary: Send Draft
+      description: Sends the specified, existing draft to the recipients in the To,
+        Cc, and Bcc headers
+      operationId: gmail.users.drafts.send
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Email
+  /{userId}/drafts/{id}:
+    delete:
+      summary: Delete Draft
+      description: Immediately and permanently deletes the specified draft
+      operationId: gmail.users.drafts.delete
+      parameters:
+      - in: path
+        name: id
+        description: The ID of the draft to delete
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Email
+    get:
+      summary: Get Draft
+      description: Gets the specified draft
+      operationId: gmail.users.drafts.get
+      parameters:
+      - in: query
+        name: format
+        description: The format to return the draft in
+      - in: path
+        name: id
+        description: The ID of the draft to retrieve
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Email
+    put:
+      summary: Update Draft
+      description: Replaces a draft's content
+      operationId: gmail.users.drafts.update
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: path
+        name: id
+        description: The ID of the draft to update
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Email
+  /{userId}/history:
+    get:
+      summary: Get History
+      description: Lists the history of all changes to the given mailbox
+      operationId: gmail.users.history.list
+      parameters:
+      - in: query
+        name: historyTypes
+        description: History types to be returned by the function
+      - in: query
+        name: labelId
+        description: Only return messages with a label matching the ID
+      - in: query
+        name: maxResults
+        description: The maximum number of history records to return
+      - in: query
+        name: pageToken
+        description: Page token to retrieve a specific page of results in the list
+      - in: query
+        name: startHistoryId
+        description: Required
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - History
+  /{userId}/labels:
+    get:
+      summary: Get Labels
+      description: Lists all labels in the user's mailbox
+      operationId: gmail.users.labels.list
+      parameters:
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Label
+    post:
+      summary: Create Label
+      description: Creates a new label
+      operationId: gmail.users.labels.create
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Label
+  /{userId}/labels/{id}:
+    delete:
+      summary: Delete Lbel
+      description: Immediately and permanently deletes the specified label and removes
+        it from any messages and threads that it is applied to
+      operationId: gmail.users.labels.delete
+      parameters:
+      - in: path
+        name: id
+        description: The ID of the label to delete
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Label
+    get:
+      summary: Get Label
+      description: Gets the specified label
+      operationId: gmail.users.labels.get
+      parameters:
+      - in: path
+        name: id
+        description: The ID of the label to retrieve
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Label
+    patch:
+      summary: Update Label
+      description: Updates the specified label
+      operationId: gmail.users.labels.patch
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: path
+        name: id
+        description: The ID of the label to update
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Label
+    put:
+      summary: Update Label
+      description: Updates the specified label
+      operationId: gmail.users.labels.update
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: path
+        name: id
+        description: The ID of the label to update
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Label
+  /{userId}/messages:
+    get:
+      summary: Get Message
+      description: Lists the messages in the user's mailbox
+      operationId: gmail.users.messages.list
+      parameters:
+      - in: query
+        name: includeSpamTrash
+        description: Include messages from SPAM and TRASH in the results
+      - in: query
+        name: labelIds
+        description: Only return messages with labels that match all of the specified
+          label IDs
+      - in: query
+        name: maxResults
+        description: Maximum number of messages to return
+      - in: query
+        name: pageToken
+        description: Page token to retrieve a specific page of results in the list
+      - in: query
+        name: q
+        description: Only return messages matching the specified query
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Email
+    post:
+      summary: Create Message
+      description: Directly inserts a message into only this user's mailbox similar
+        to IMAP APPEND, bypassing most scanning and classification
+      operationId: gmail.users.messages.insert
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: query
+        name: deleted
+        description: Mark the email as permanently deleted (not TRASH) and only visible
+          in Google Vault to a Vault administrator
+      - in: query
+        name: internalDateSource
+        description: Source for Gmail's internal date of the message
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Email
+  /{userId}/messages/batchDelete:
+    post:
+      summary: Delete Messages
+      description: Deletes many messages by message ID
+      operationId: gmail.users.messages.batchDelete
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Email
+  /{userId}/messages/batchModify:
+    post:
+      summary: Update Label
+      description: Modifies the labels on the specified messages
+      operationId: gmail.users.messages.batchModify
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Email
+  /{userId}/messages/import:
+    post:
+      summary: Import Message
+      description: Imports a message into only this user's mailbox, with standard
+        email delivery scanning and classification similar to receiving via SMTP
+      operationId: gmail.users.messages.import
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: query
+        name: deleted
+        description: Mark the email as permanently deleted (not TRASH) and only visible
+          in Google Vault to a Vault administrator
+      - in: query
+        name: internalDateSource
+        description: Source for Gmail's internal date of the message
+      - in: query
+        name: neverMarkSpam
+        description: Ignore the Gmail spam classifier decision and never mark this
+          email as SPAM in the mailbox
+      - in: query
+        name: processForCalendar
+        description: Process calendar invites in the email and add any extracted meetings
+          to the Google Calendar for this user
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Email
+  /{userId}/messages/send:
+    post:
+      summary: Send Message
+      description: Sends the specified message to the recipients in the To, Cc, and
+        Bcc headers
+      operationId: gmail.users.messages.send
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Email
+  /{userId}/messages/{id}:
+    delete:
+      summary: Delete Message
+      description: Immediately and permanently deletes the specified message
+      operationId: gmail.users.messages.delete
+      parameters:
+      - in: path
+        name: id
+        description: The ID of the message to delete
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Email
+    get:
+      summary: Get Message
+      description: Gets the specified message
+      operationId: gmail.users.messages.get
+      parameters:
+      - in: query
+        name: format
+        description: The format to return the message in
+      - in: path
+        name: id
+        description: The ID of the message to retrieve
+      - in: query
+        name: metadataHeaders
+        description: When given and format is METADATA, only include headers specified
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Email
+  /{userId}/messages/{id}/modify:
+    post:
+      summary: Modify message
+      description: Modifies the labels on the specified message
+      operationId: gmail.users.messages.modify
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: path
+        name: id
+        description: The ID of the message to modify
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Email
+  /{userId}/messages/{id}/trash:
+    post:
+      summary: Trash Message
+      description: Moves the specified message to the trash
+      operationId: gmail.users.messages.trash
+      parameters:
+      - in: path
+        name: id
+        description: The ID of the message to Trash
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Email
+  /{userId}/messages/{id}/untrash:
+    post:
+      summary: UnTrash Message
+      description: Removes the specified message from the trash
+      operationId: gmail.users.messages.untrash
+      parameters:
+      - in: path
+        name: id
+        description: The ID of the message to remove from Trash
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Email
+  /{userId}/messages/{messageId}/attachments/{id}:
+    get:
+      summary: Get Attachments
+      description: Gets the specified message attachment
+      operationId: gmail.users.messages.attachments.get
+      parameters:
+      - in: path
+        name: id
+        description: The ID of the attachment
+      - in: path
+        name: messageId
+        description: The ID of the message containing the attachment
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Email
+  /{userId}/profile:
+    get:
+      summary: Get Profile
+      description: Gets the current user's Gmail profile
+      operationId: gmail.users.getProfile
+      parameters:
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - User
+  /{userId}/settings/autoForwarding:
+    get:
+      summary: Get Auto-Forwarding Settings
+      description: Gets the auto-forwarding setting for the specified account
+      operationId: gmail.users.settings.getAutoForwarding
+      parameters:
+      - in: path
+        name: userId
+        description: User's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Settings
+    put:
+      summary: Update Auto-Forwarding Settings
+      description: Updates the auto-forwarding setting for the specified account
+      operationId: gmail.users.settings.updateAutoForwarding
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: path
+        name: userId
+        description: User's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Settings
+  /{userId}/settings/filters:
+    get:
+      summary: Get Message Filters
+      description: Lists the message filters of a Gmail user
+      operationId: gmail.users.settings.filters.list
+      parameters:
+      - in: path
+        name: userId
+        description: User's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Filters
+    post:
+      summary: Create Message Filters
+      description: Creates a filter
+      operationId: gmail.users.settings.filters.create
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: path
+        name: userId
+        description: User's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Filters
+  /{userId}/settings/filters/{id}:
+    delete:
+      summary: Delete Message Filter
+      description: Deletes a filter
+      operationId: gmail.users.settings.filters.delete
+      parameters:
+      - in: path
+        name: id
+        description: The ID of the filter to be deleted
+      - in: path
+        name: userId
+        description: User's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Filters
+    get:
+      summary: Get Message Filter
+      description: Gets a filter
+      operationId: gmail.users.settings.filters.get
+      parameters:
+      - in: path
+        name: id
+        description: The ID of the filter to be fetched
+      - in: path
+        name: userId
+        description: User's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Filters
+  /{userId}/settings/forwardingAddresses:
+    get:
+      summary: Get Forward Addresses
+      description: Lists the forwarding addresses for the specified account
+      operationId: gmail.users.settings.forwardingAddresses.list
+      parameters:
+      - in: path
+        name: userId
+        description: User's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Forwarding Address
+    post:
+      summary: Create Forward Addresse
+      description: Creates a forwarding address
+      operationId: gmail.users.settings.forwardingAddresses.create
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: path
+        name: userId
+        description: User's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Forwarding Address
+  /{userId}/settings/forwardingAddresses/{forwardingEmail}:
+    delete:
+      summary: Delete Forward Address
+      description: Deletes the specified forwarding address and revokes any verification
+        that may have been required
+      operationId: gmail.users.settings.forwardingAddresses.delete
+      parameters:
+      - in: path
+        name: forwardingEmail
+        description: The forwarding address to be deleted
+      - in: path
+        name: userId
+        description: User's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Forwarding Address
+    get:
+      summary: GGetet Forward Address
+      description: Gets the specified forwarding address
+      operationId: gmail.users.settings.forwardingAddresses.get
+      parameters:
+      - in: path
+        name: forwardingEmail
+        description: The forwarding address to be retrieved
+      - in: path
+        name: userId
+        description: User's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Forwarding Address
+  /{userId}/settings/imap:
+    get:
+      summary: Gets IMAP Settings
+      description: Gets IMAP settings
+      operationId: gmail.users.settings.getImap
+      parameters:
+      - in: path
+        name: userId
+        description: User's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - IMAP Settings
+    put:
+      summary: Update IMAP Setting
+      description: Updates IMAP settings
+      operationId: gmail.users.settings.updateImap
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: path
+        name: userId
+        description: User's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - IMAP Settings
+  /{userId}/settings/pop:
+    get:
+      summary: Gets POP Settings
+      description: Gets POP settings
+      operationId: gmail.users.settings.getPop
+      parameters:
+      - in: path
+        name: userId
+        description: User's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - ""
+    put:
+      summary: Update IMAP Setting
+      description: Updates POP settings
+      operationId: gmail.users.settings.updatePop
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: path
+        name: userId
+        description: User's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - POP Settings
+  /{userId}/settings/sendAs:
+    get:
+      summary: Send As Alias
+      description: Lists the send-as aliases for the specified account
+      operationId: gmail.users.settings.sendAs.list
+      parameters:
+      - in: path
+        name: userId
+        description: User's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Alias
+    post:
+      summary: Create Alias
+      description: Creates a custom "from" send-as alias
+      operationId: gmail.users.settings.sendAs.create
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: path
+        name: userId
+        description: User's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Alias
+  /{userId}/settings/sendAs/{sendAsEmail}:
+    delete:
+      summary: Delete Alias
+      description: Deletes the specified send-as alias
+      operationId: gmail.users.settings.sendAs.delete
+      parameters:
+      - in: path
+        name: sendAsEmail
+        description: The send-as alias to be deleted
+      - in: path
+        name: userId
+        description: User's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Alias
+    get:
+      summary: Get Alias
+      description: Gets the specified send-as alias
+      operationId: gmail.users.settings.sendAs.get
+      parameters:
+      - in: path
+        name: sendAsEmail
+        description: The send-as alias to be retrieved
+      - in: path
+        name: userId
+        description: User's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Alias
+    patch:
+      summary: Update Alias
+      description: Updates a send-as alias
+      operationId: gmail.users.settings.sendAs.patch
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: path
+        name: sendAsEmail
+        description: The send-as alias to be updated
+      - in: path
+        name: userId
+        description: User's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Alias
+    put:
+      summary: Update Alias
+      description: Updates a send-as alias
+      operationId: gmail.users.settings.sendAs.update
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: path
+        name: sendAsEmail
+        description: The send-as alias to be updated
+      - in: path
+        name: userId
+        description: User's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Alias
+  /{userId}/settings/sendAs/{sendAsEmail}/smimeInfo:
+    get:
+      summary: Get S/MIME Configurations
+      description: Lists S/MIME configs for the specified send-as alias
+      operationId: gmail.users.settings.sendAs.smimeInfo.list
+      parameters:
+      - in: path
+        name: sendAsEmail
+        description: The email address that appears in the "From:" header for mail
+          sent using this alias
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - S/MIME Configuration
+    post:
+      summary: Create S/MIME Configurations
+      description: Insert (upload) the given S/MIME config for the specified send-as
+        alias
+      operationId: gmail.users.settings.sendAs.smimeInfo.insert
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: path
+        name: sendAsEmail
+        description: The email address that appears in the "From:" header for mail
+          sent using this alias
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - S/MIME Configuration
+  /{userId}/settings/sendAs/{sendAsEmail}/smimeInfo/{id}:
+    delete:
+      summary: Delete S/MIME Configurations
+      description: Deletes the specified S/MIME config for the specified send-as alias
+      operationId: gmail.users.settings.sendAs.smimeInfo.delete
+      parameters:
+      - in: path
+        name: id
+        description: The immutable ID for the SmimeInfo
+      - in: path
+        name: sendAsEmail
+        description: The email address that appears in the "From:" header for mail
+          sent using this alias
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - S/MIME Configuration
+    get:
+      summary: Get S/MIME Configuration
+      description: Gets the specified S/MIME config for the specified send-as alias
+      operationId: gmail.users.settings.sendAs.smimeInfo.get
+      parameters:
+      - in: path
+        name: id
+        description: The immutable ID for the SmimeInfo
+      - in: path
+        name: sendAsEmail
+        description: The email address that appears in the "From:" header for mail
+          sent using this alias
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - S/MIME Configuration
+  /{userId}/settings/sendAs/{sendAsEmail}/smimeInfo/{id}/setDefault:
+    post:
+      summary: Create Default S/MIME Configurations
+      description: Sets the default S/MIME config for the specified send-as alias
+      operationId: gmail.users.settings.sendAs.smimeInfo.setDefault
+      parameters:
+      - in: path
+        name: id
+        description: The immutable ID for the SmimeInfo
+      - in: path
+        name: sendAsEmail
+        description: The email address that appears in the "From:" header for mail
+          sent using this alias
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - S/MIME Configuration
+  /{userId}/settings/sendAs/{sendAsEmail}/verify:
+    post:
+      summary: Send Verification Email
+      description: Sends a verification email to the specified send-as alias address
+      operationId: gmail.users.settings.sendAs.verify
+      parameters:
+      - in: path
+        name: sendAsEmail
+        description: The send-as alias to be verified
+      - in: path
+        name: userId
+        description: User's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Verification
+  /{userId}/settings/vacation:
+    get:
+      summary: Get Vacation Settings
+      description: Gets vacation responder settings
+      operationId: gmail.users.settings.getVacation
+      parameters:
+      - in: path
+        name: userId
+        description: User's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Vacation Settings
+    put:
+      summary: Update Vacation Settings
+      description: Updates vacation responder settings
+      operationId: gmail.users.settings.updateVacation
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: path
+        name: userId
+        description: User's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Vacation Settings
+  /{userId}/stop:
+    post:
+      summary: Stop Push Notifications
+      description: Stop receiving push notifications for the given user mailbox
+      operationId: gmail.users.stop
+      parameters:
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Push Notification
+  /{userId}/threads:
+    get:
+      summary: Get Threads
+      description: Lists the threads in the user's mailbox
+      operationId: gmail.users.threads.list
+      parameters:
+      - in: query
+        name: includeSpamTrash
+        description: Include threads from SPAM and TRASH in the results
+      - in: query
+        name: labelIds
+        description: Only return threads with labels that match all of the specified
+          label IDs
+      - in: query
+        name: maxResults
+        description: Maximum number of threads to return
+      - in: query
+        name: pageToken
+        description: Page token to retrieve a specific page of results in the list
+      - in: query
+        name: q
+        description: Only return threads matching the specified query
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Email Thread
+  /{userId}/threads/{id}:
+    delete:
+      summary: Delete Threads
+      description: Immediately and permanently deletes the specified thread
+      operationId: gmail.users.threads.delete
+      parameters:
+      - in: path
+        name: id
+        description: ID of the Thread to delete
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Email Thread
+    get:
+      summary: Get Threads
+      description: Gets the specified thread
+      operationId: gmail.users.threads.get
+      parameters:
+      - in: query
+        name: format
+        description: The format to return the messages in
+      - in: path
+        name: id
+        description: The ID of the thread to retrieve
+      - in: query
+        name: metadataHeaders
+        description: When given and format is METADATA, only include headers specified
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Email Thread
+  /{userId}/threads/{id}/modify:
+    post:
+      summary: Modify Thread labels
+      description: Modifies the labels applied to the thread
+      operationId: gmail.users.threads.modify
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: path
+        name: id
+        description: The ID of the thread to modify
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Email Thread
+  /{userId}/threads/{id}/trash:
+    post:
+      summary: Trash Thread
+      description: Moves the specified thread to the trash
+      operationId: gmail.users.threads.trash
+      parameters:
+      - in: path
+        name: id
+        description: The ID of the thread to Trash
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Email Thread
+  /{userId}/threads/{id}/untrash:
+    post:
+      summary: UnTrash Threat
+      description: Removes the specified thread from the trash
+      operationId: gmail.users.threads.untrash
+      parameters:
+      - in: path
+        name: id
+        description: The ID of the thread to remove from Trash
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Email Thread
+  /{userId}/watch:
+    post:
+      summary: Send Push Notification
+      description: Set up or update a push notification watch on the given user mailbox
+      operationId: gmail.users.watch
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: path
+        name: userId
+        description: The user's email address
+      responses:
+        200:
+          description: OK
+      tags:
+      - Push Notification
+definitions:
+  AutoForwarding:
+    properties:
+      disposition:
+        description: This is a default description.
+        type: post
+      emailAddress:
+        description: This is a default description.
+        type: post
+      enabled:
+        description: This is a default description.
+        type: post
+  BatchDeleteMessagesRequest:
+    properties:
+      ids:
+        description: This is a default description.
+        type: post
+  BatchModifyMessagesRequest:
+    properties:
+      addLabelIds:
+        description: This is a default description.
+        type: post
+      ids:
+        description: This is a default description.
+        type: post
+      removeLabelIds:
+        description: This is a default description.
+        type: post
+  Draft:
+    properties:
+      id:
+        description: This is a default description.
+        type: post
+  Filter:
+    properties:
+      id:
+        description: This is a default description.
+        type: post
+  FilterAction:
+    properties:
+      addLabelIds:
+        description: This is a default description.
+        type: post
+      forward:
+        description: This is a default description.
+        type: post
+      removeLabelIds:
+        description: This is a default description.
+        type: post
+  FilterCriteria:
+    properties:
+      excludeChats:
+        description: This is a default description.
+        type: post
+      from:
+        description: This is a default description.
+        type: post
+      hasAttachment:
+        description: This is a default description.
+        type: post
+      negatedQuery:
+        description: This is a default description.
+        type: post
+      query:
+        description: This is a default description.
+        type: post
+      size:
+        description: This is a default description.
+        type: post
+      sizeComparison:
+        description: This is a default description.
+        type: post
+      subject:
+        description: This is a default description.
+        type: post
+      to:
+        description: This is a default description.
+        type: post
+  ForwardingAddress:
+    properties:
+      forwardingEmail:
+        description: This is a default description.
+        type: post
+      verificationStatus:
+        description: This is a default description.
+        type: post
+  History:
+    properties:
+      id:
+        description: This is a default description.
+        type: post
+      labelsAdded:
+        description: This is a default description.
+        type: post
+      labelsRemoved:
+        description: This is a default description.
+        type: post
+      messages:
+        description: This is a default description.
+        type: post
+      messagesAdded:
+        description: This is a default description.
+        type: post
+      messagesDeleted:
+        description: This is a default description.
+        type: post
+  HistoryLabelAdded:
+    properties:
+      labelIds:
+        description: This is a default description.
+        type: post
+  HistoryLabelRemoved:
+    properties:
+      labelIds:
+        description: This is a default description.
+        type: post
+  HistoryMessageAdded:
+    properties: []
+  HistoryMessageDeleted:
+    properties: []
+  ImapSettings:
+    properties:
+      autoExpunge:
+        description: This is a default description.
+        type: post
+      enabled:
+        description: This is a default description.
+        type: post
+      expungeBehavior:
+        description: This is a default description.
+        type: post
+      maxFolderSize:
+        description: This is a default description.
+        type: post
+  Label:
+    properties:
+      id:
+        description: This is a default description.
+        type: post
+      labelListVisibility:
+        description: This is a default description.
+        type: post
+      messageListVisibility:
+        description: This is a default description.
+        type: post
+      messagesTotal:
+        description: This is a default description.
+        type: post
+      messagesUnread:
+        description: This is a default description.
+        type: post
+      name:
+        description: This is a default description.
+        type: post
+      threadsTotal:
+        description: This is a default description.
+        type: post
+      threadsUnread:
+        description: This is a default description.
+        type: post
+      type:
+        description: This is a default description.
+        type: post
+  ListDraftsResponse:
+    properties:
+      drafts:
+        description: This is a default description.
+        type: post
+      nextPageToken:
+        description: This is a default description.
+        type: post
+      resultSizeEstimate:
+        description: This is a default description.
+        type: post
+  ListFiltersResponse:
+    properties:
+      filter:
+        description: This is a default description.
+        type: post
+  ListForwardingAddressesResponse:
+    properties:
+      forwardingAddresses:
+        description: This is a default description.
+        type: post
+  ListHistoryResponse:
+    properties:
+      history:
+        description: This is a default description.
+        type: post
+      historyId:
+        description: This is a default description.
+        type: post
+      nextPageToken:
+        description: This is a default description.
+        type: post
+  ListLabelsResponse:
+    properties:
+      labels:
+        description: This is a default description.
+        type: post
+  ListMessagesResponse:
+    properties:
+      messages:
+        description: This is a default description.
+        type: post
+      nextPageToken:
+        description: This is a default description.
+        type: post
+      resultSizeEstimate:
+        description: This is a default description.
+        type: post
+  ListSendAsResponse:
+    properties:
+      sendAs:
+        description: This is a default description.
+        type: post
+  ListSmimeInfoResponse:
+    properties:
+      smimeInfo:
+        description: This is a default description.
+        type: post
+  ListThreadsResponse:
+    properties:
+      nextPageToken:
+        description: This is a default description.
+        type: post
+      resultSizeEstimate:
+        description: This is a default description.
+        type: post
+      threads:
+        description: This is a default description.
+        type: post
+  Message:
+    properties:
+      historyId:
+        description: This is a default description.
+        type: post
+      id:
+        description: This is a default description.
+        type: post
+      internalDate:
+        description: This is a default description.
+        type: post
+      labelIds:
+        description: This is a default description.
+        type: post
+      raw:
+        description: This is a default description.
+        type: post
+      sizeEstimate:
+        description: This is a default description.
+        type: post
+      snippet:
+        description: This is a default description.
+        type: post
+      threadId:
+        description: This is a default description.
+        type: post
+  MessagePart:
+    properties:
+      filename:
+        description: This is a default description.
+        type: post
+      headers:
+        description: This is a default description.
+        type: post
+      mimeType:
+        description: This is a default description.
+        type: post
+      partId:
+        description: This is a default description.
+        type: post
+      parts:
+        description: This is a default description.
+        type: post
+  MessagePartBody:
+    properties:
+      attachmentId:
+        description: This is a default description.
+        type: post
+      data:
+        description: This is a default description.
+        type: post
+      size:
+        description: This is a default description.
+        type: post
+  MessagePartHeader:
+    properties:
+      name:
+        description: This is a default description.
+        type: post
+      value:
+        description: This is a default description.
+        type: post
+  ModifyMessageRequest:
+    properties:
+      addLabelIds:
+        description: This is a default description.
+        type: post
+      removeLabelIds:
+        description: This is a default description.
+        type: post
+  ModifyThreadRequest:
+    properties:
+      addLabelIds:
+        description: This is a default description.
+        type: post
+      removeLabelIds:
+        description: This is a default description.
+        type: post
+  PopSettings:
+    properties:
+      accessWindow:
+        description: This is a default description.
+        type: post
+      disposition:
+        description: This is a default description.
+        type: post
+  Profile:
+    properties:
+      emailAddress:
+        description: This is a default description.
+        type: post
+      historyId:
+        description: This is a default description.
+        type: post
+      messagesTotal:
+        description: This is a default description.
+        type: post
+      threadsTotal:
+        description: This is a default description.
+        type: post
+  SendAs:
+    properties:
+      displayName:
+        description: This is a default description.
+        type: post
+      isDefault:
+        description: This is a default description.
+        type: post
+      isPrimary:
+        description: This is a default description.
+        type: post
+      replyToAddress:
+        description: This is a default description.
+        type: post
+      sendAsEmail:
+        description: This is a default description.
+        type: post
+      signature:
+        description: This is a default description.
+        type: post
+      treatAsAlias:
+        description: This is a default description.
+        type: post
+      verificationStatus:
+        description: This is a default description.
+        type: post
+  SmimeInfo:
+    properties:
+      encryptedKeyPassword:
+        description: This is a default description.
+        type: post
+      expiration:
+        description: This is a default description.
+        type: post
+      id:
+        description: This is a default description.
+        type: post
+      isDefault:
+        description: This is a default description.
+        type: post
+      issuerCn:
+        description: This is a default description.
+        type: post
+      pem:
+        description: This is a default description.
+        type: post
+      pkcs12:
+        description: This is a default description.
+        type: post
+  SmtpMsa:
+    properties:
+      host:
+        description: This is a default description.
+        type: post
+      password:
+        description: This is a default description.
+        type: post
+      port:
+        description: This is a default description.
+        type: post
+      securityMode:
+        description: This is a default description.
+        type: post
+      username:
+        description: This is a default description.
+        type: post
+  Thread:
+    properties:
+      historyId:
+        description: This is a default description.
+        type: post
+      id:
+        description: This is a default description.
+        type: post
+      messages:
+        description: This is a default description.
+        type: post
+      snippet:
+        description: This is a default description.
+        type: post
+  VacationSettings:
+    properties:
+      enableAutoReply:
+        description: This is a default description.
+        type: post
+      endTime:
+        description: This is a default description.
+        type: post
+      responseBodyHtml:
+        description: This is a default description.
+        type: post
+      responseBodyPlainText:
+        description: This is a default description.
+        type: post
+      responseSubject:
+        description: This is a default description.
+        type: post
+      restrictToContacts:
+        description: This is a default description.
+        type: post
+      restrictToDomain:
+        description: This is a default description.
+        type: post
+      startTime:
+        description: This is a default description.
+        type: post
+  WatchRequest:
+    properties:
+      labelFilterAction:
+        description: This is a default description.
+        type: post
+      labelIds:
+        description: This is a default description.
+        type: post
+      topicName:
+        description: This is a default description.
+        type: post
+  WatchResponse:
+    properties:
+      expiration:
+        description: This is a default description.
+        type: post
+      historyId:
+        description: This is a default description.
+        type: post

--- a/google-calendar-api-openapi-spec.yaml
+++ b/google-calendar-api-openapi-spec.yaml
@@ -1,0 +1,1412 @@
+swagger: "2.0"
+info:
+  title: Calendar
+  description: Manipulates events and other calendar data.
+  contact:
+    name: Google
+    url: https://google.com
+  version: v3
+host: www.googleapis.com
+basePath: /calendar/v3
+schemes:
+- http
+produces:
+- application/json
+consumes:
+- application/json
+paths:
+  /calendars:
+    post:
+      summary: Create Calendar
+      description: Creates a secondary calendar
+      operationId: calendar.calendars.insert
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      responses:
+        200:
+          description: OK
+      tags:
+      - Calendar
+  /calendars/{calendarId}:
+    delete:
+      summary: CreaDeletete Calendar
+      description: Deletes a secondary calendar
+      operationId: calendar.calendars.delete
+      parameters:
+      - in: path
+        name: calendarId
+        description: Calendar identifier
+      responses:
+        200:
+          description: OK
+      tags:
+      - Calendar
+    get:
+      summary: Get Calendar
+      description: Returns metadata for a calendar
+      operationId: calendar.calendars.get
+      parameters:
+      - in: path
+        name: calendarId
+        description: Calendar identifier
+      responses:
+        200:
+          description: OK
+      tags:
+      - Calendar
+    patch:
+      summary: Update Calendar
+      description: Updates metadata for a calendar
+      operationId: calendar.calendars.patch
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: path
+        name: calendarId
+        description: Calendar identifier
+      responses:
+        200:
+          description: OK
+      tags:
+      - Calendar
+    put:
+      summary: Update Calendar
+      description: Updates metadata for a calendar
+      operationId: calendar.calendars.update
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: path
+        name: calendarId
+        description: Calendar identifier
+      responses:
+        200:
+          description: OK
+      tags:
+      - Calendar
+  /calendars/{calendarId}/acl:
+    get:
+      summary: Get Calendar ACL
+      description: Returns the rules in the access control list for the calendar
+      operationId: calendar.acl.list
+      parameters:
+      - in: path
+        name: calendarId
+        description: Calendar identifier
+      - in: query
+        name: maxResults
+        description: Maximum number of entries returned on one result page
+      - in: query
+        name: pageToken
+        description: Token specifying which result page to return
+      - in: query
+        name: showDeleted
+        description: Whether to include deleted ACLs in the result
+      - in: query
+        name: syncToken
+        description: Token obtained from the nextSyncToken field returned on the last
+          page of results from the previous list request
+      responses:
+        200:
+          description: OK
+      tags:
+      - Calendar ACL
+    post:
+      summary: Create Calendar ACL
+      description: Creates an access control rule
+      operationId: calendar.acl.insert
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: path
+        name: calendarId
+        description: Calendar identifier
+      responses:
+        200:
+          description: OK
+      tags:
+      - Calendar ACL
+  /calendars/{calendarId}/acl/watch:
+    post:
+      summary: Watch Calendar ACL
+      description: Watch for changes to ACL resources
+      operationId: calendar.acl.watch
+      parameters:
+      - in: path
+        name: calendarId
+        description: Calendar identifier
+      - in: query
+        name: maxResults
+        description: Maximum number of entries returned on one result page
+      - in: query
+        name: pageToken
+        description: Token specifying which result page to return
+      - in: body
+        name: resource
+        schema:
+          $ref: '#/definitions/holder'
+      - in: query
+        name: showDeleted
+        description: Whether to include deleted ACLs in the result
+      - in: query
+        name: syncToken
+        description: Token obtained from the nextSyncToken field returned on the last
+          page of results from the previous list request
+      responses:
+        200:
+          description: OK
+      tags:
+      - Calendar ACL
+  /calendars/{calendarId}/acl/{ruleId}:
+    delete:
+      summary: Delete Calendar ACL
+      description: Deletes an access control rule
+      operationId: calendar.acl.delete
+      parameters:
+      - in: path
+        name: calendarId
+        description: Calendar identifier
+      - in: path
+        name: ruleId
+        description: ACL rule identifier
+      responses:
+        200:
+          description: OK
+      tags:
+      - Calendar ACL
+    get:
+      summary: Get Calendar ACL
+      description: Returns an access control rule
+      operationId: calendar.acl.get
+      parameters:
+      - in: path
+        name: calendarId
+        description: Calendar identifier
+      - in: path
+        name: ruleId
+        description: ACL rule identifier
+      responses:
+        200:
+          description: OK
+      tags:
+      - Calendar ACL
+    patch:
+      summary: Update Calendar ACL
+      description: Updates an access control rule
+      operationId: calendar.acl.patch
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: path
+        name: calendarId
+        description: Calendar identifier
+      - in: path
+        name: ruleId
+        description: ACL rule identifier
+      responses:
+        200:
+          description: OK
+      tags:
+      - Calendar ACL
+    put:
+      summary: Update Calendar ACL
+      description: Updates an access control rule
+      operationId: calendar.acl.update
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: path
+        name: calendarId
+        description: Calendar identifier
+      - in: path
+        name: ruleId
+        description: ACL rule identifier
+      responses:
+        200:
+          description: OK
+      tags:
+      - Calendar ACL
+  /calendars/{calendarId}/clear:
+    post:
+      summary: Clear Primary Calendar
+      description: Clears a primary calendar
+      operationId: calendar.calendars.clear
+      parameters:
+      - in: path
+        name: calendarId
+        description: Calendar identifier
+      responses:
+        200:
+          description: OK
+      tags:
+      - Calendar
+  /calendars/{calendarId}/events:
+    get:
+      summary: Get Events
+      description: Returns events on the specified calendar
+      operationId: calendar.events.list
+      parameters:
+      - in: query
+        name: alwaysIncludeEmail
+        description: Whether to always include a value in the email field for the
+          organizer, creator and attendees, even if no real email is available (i
+      - in: path
+        name: calendarId
+        description: Calendar identifier
+      - in: query
+        name: iCalUID
+        description: Specifies event ID in the iCalendar format to be included in
+          the response
+      - in: query
+        name: maxAttendees
+        description: The maximum number of attendees to include in the response
+      - in: query
+        name: maxResults
+        description: Maximum number of events returned on one result page
+      - in: query
+        name: orderBy
+        description: The order of the events returned in the result
+      - in: query
+        name: pageToken
+        description: Token specifying which result page to return
+      - in: query
+        name: privateExtendedProperty
+        description: Extended properties constraint specified as propertyName=value
+      - in: query
+        name: q
+        description: Free text search terms to find events that match these terms
+          in any field, except for extended properties
+      - in: query
+        name: sharedExtendedProperty
+        description: Extended properties constraint specified as propertyName=value
+      - in: query
+        name: showDeleted
+        description: Whether to include deleted events (with status equals "cancelled")
+          in the result
+      - in: query
+        name: showHiddenInvitations
+        description: Whether to include hidden invitations in the result
+      - in: query
+        name: singleEvents
+        description: Whether to expand recurring events into instances and only return
+          single one-off events and instances of recurring events, but not the underlying
+          recurring events themselves
+      - in: query
+        name: syncToken
+        description: Token obtained from the nextSyncToken field returned on the last
+          page of results from the previous list request
+      - in: query
+        name: timeMax
+        description: Upper bound (exclusive) for an event's start time to filter by
+      - in: query
+        name: timeMin
+        description: Lower bound (inclusive) for an event's end time to filter by
+      - in: query
+        name: timeZone
+        description: Time zone used in the response
+      - in: query
+        name: updatedMin
+        description: Lower bound for an event's last modification time (as a RFC3339
+          timestamp) to filter by
+      responses:
+        200:
+          description: OK
+      tags:
+      - Event
+    post:
+      summary: Create Event
+      description: Creates an event
+      operationId: calendar.events.insert
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: path
+        name: calendarId
+        description: Calendar identifier
+      - in: query
+        name: maxAttendees
+        description: The maximum number of attendees to include in the response
+      - in: query
+        name: sendNotifications
+        description: Whether to send notifications about the creation of the new event
+      - in: query
+        name: supportsAttachments
+        description: Whether API client performing operation supports event attachments
+      responses:
+        200:
+          description: OK
+      tags:
+      - Event
+  /calendars/{calendarId}/events/import:
+    post:
+      summary: Import Event
+      description: Imports an event
+      operationId: calendar.events.import
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: path
+        name: calendarId
+        description: Calendar identifier
+      - in: query
+        name: supportsAttachments
+        description: Whether API client performing operation supports event attachments
+      responses:
+        200:
+          description: OK
+      tags:
+      - Event
+  /calendars/{calendarId}/events/quickAdd:
+    post:
+      summary: Create Event
+      description: Creates an event based on a simple text string
+      operationId: calendar.events.quickAdd
+      parameters:
+      - in: path
+        name: calendarId
+        description: Calendar identifier
+      - in: query
+        name: sendNotifications
+        description: Whether to send notifications about the creation of the event
+      - in: query
+        name: text
+        description: The text describing the event to be created
+      responses:
+        200:
+          description: OK
+      tags:
+      - Event
+  /calendars/{calendarId}/events/watch:
+    post:
+      summary: Watch Event
+      description: Watch for changes to Events resources
+      operationId: calendar.events.watch
+      parameters:
+      - in: query
+        name: alwaysIncludeEmail
+        description: Whether to always include a value in the email field for the
+          organizer, creator and attendees, even if no real email is available (i
+      - in: path
+        name: calendarId
+        description: Calendar identifier
+      - in: query
+        name: iCalUID
+        description: Specifies event ID in the iCalendar format to be included in
+          the response
+      - in: query
+        name: maxAttendees
+        description: The maximum number of attendees to include in the response
+      - in: query
+        name: maxResults
+        description: Maximum number of events returned on one result page
+      - in: query
+        name: orderBy
+        description: The order of the events returned in the result
+      - in: query
+        name: pageToken
+        description: Token specifying which result page to return
+      - in: query
+        name: privateExtendedProperty
+        description: Extended properties constraint specified as propertyName=value
+      - in: query
+        name: q
+        description: Free text search terms to find events that match these terms
+          in any field, except for extended properties
+      - in: body
+        name: resource
+        schema:
+          $ref: '#/definitions/holder'
+      - in: query
+        name: sharedExtendedProperty
+        description: Extended properties constraint specified as propertyName=value
+      - in: query
+        name: showDeleted
+        description: Whether to include deleted events (with status equals "cancelled")
+          in the result
+      - in: query
+        name: showHiddenInvitations
+        description: Whether to include hidden invitations in the result
+      - in: query
+        name: singleEvents
+        description: Whether to expand recurring events into instances and only return
+          single one-off events and instances of recurring events, but not the underlying
+          recurring events themselves
+      - in: query
+        name: syncToken
+        description: Token obtained from the nextSyncToken field returned on the last
+          page of results from the previous list request
+      - in: query
+        name: timeMax
+        description: Upper bound (exclusive) for an event's start time to filter by
+      - in: query
+        name: timeMin
+        description: Lower bound (inclusive) for an event's end time to filter by
+      - in: query
+        name: timeZone
+        description: Time zone used in the response
+      - in: query
+        name: updatedMin
+        description: Lower bound for an event's last modification time (as a RFC3339
+          timestamp) to filter by
+      responses:
+        200:
+          description: OK
+      tags:
+      - Event
+  /calendars/{calendarId}/events/{eventId}:
+    delete:
+      summary: Delete Event
+      description: Deletes an event
+      operationId: calendar.events.delete
+      parameters:
+      - in: path
+        name: calendarId
+        description: Calendar identifier
+      - in: path
+        name: eventId
+        description: Event identifier
+      - in: query
+        name: sendNotifications
+        description: Whether to send notifications about the deletion of the event
+      responses:
+        200:
+          description: OK
+      tags:
+      - Event
+    get:
+      summary: Get Event
+      description: Returns an event
+      operationId: calendar.events.get
+      parameters:
+      - in: query
+        name: alwaysIncludeEmail
+        description: Whether to always include a value in the email field for the
+          organizer, creator and attendees, even if no real email is available (i
+      - in: path
+        name: calendarId
+        description: Calendar identifier
+      - in: path
+        name: eventId
+        description: Event identifier
+      - in: query
+        name: maxAttendees
+        description: The maximum number of attendees to include in the response
+      - in: query
+        name: timeZone
+        description: Time zone used in the response
+      responses:
+        200:
+          description: OK
+      tags:
+      - Event
+    patch:
+      summary: Update Event
+      description: Updates an event
+      operationId: calendar.events.patch
+      parameters:
+      - in: query
+        name: alwaysIncludeEmail
+        description: Whether to always include a value in the email field for the
+          organizer, creator and attendees, even if no real email is available (i
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: path
+        name: calendarId
+        description: Calendar identifier
+      - in: path
+        name: eventId
+        description: Event identifier
+      - in: query
+        name: maxAttendees
+        description: The maximum number of attendees to include in the response
+      - in: query
+        name: sendNotifications
+        description: Whether to send notifications about the event update (e
+      - in: query
+        name: supportsAttachments
+        description: Whether API client performing operation supports event attachments
+      responses:
+        200:
+          description: OK
+      tags:
+      - Event
+    put:
+      summary: Update Event
+      description: Updates an event
+      operationId: calendar.events.update
+      parameters:
+      - in: query
+        name: alwaysIncludeEmail
+        description: Whether to always include a value in the email field for the
+          organizer, creator and attendees, even if no real email is available (i
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: path
+        name: calendarId
+        description: Calendar identifier
+      - in: path
+        name: eventId
+        description: Event identifier
+      - in: query
+        name: maxAttendees
+        description: The maximum number of attendees to include in the response
+      - in: query
+        name: sendNotifications
+        description: Whether to send notifications about the event update (e
+      - in: query
+        name: supportsAttachments
+        description: Whether API client performing operation supports event attachments
+      responses:
+        200:
+          description: OK
+      tags:
+      - Event
+  /calendars/{calendarId}/events/{eventId}/instances:
+    get:
+      summary: Get Event Instance
+      description: Returns instances of the specified recurring event
+      operationId: calendar.events.instances
+      parameters:
+      - in: query
+        name: alwaysIncludeEmail
+        description: Whether to always include a value in the email field for the
+          organizer, creator and attendees, even if no real email is available (i
+      - in: path
+        name: calendarId
+        description: Calendar identifier
+      - in: path
+        name: eventId
+        description: Recurring event identifier
+      - in: query
+        name: maxAttendees
+        description: The maximum number of attendees to include in the response
+      - in: query
+        name: maxResults
+        description: Maximum number of events returned on one result page
+      - in: query
+        name: originalStart
+        description: The original start time of the instance in the result
+      - in: query
+        name: pageToken
+        description: Token specifying which result page to return
+      - in: query
+        name: showDeleted
+        description: Whether to include deleted events (with status equals "cancelled")
+          in the result
+      - in: query
+        name: timeMax
+        description: Upper bound (exclusive) for an event's start time to filter by
+      - in: query
+        name: timeMin
+        description: Lower bound (inclusive) for an event's end time to filter by
+      - in: query
+        name: timeZone
+        description: Time zone used in the response
+      responses:
+        200:
+          description: OK
+      tags:
+      - Event
+  /calendars/{calendarId}/events/{eventId}/move:
+    post:
+      summary: Move Event
+      description: Moves an event to another calendar, i
+      operationId: calendar.events.move
+      parameters:
+      - in: path
+        name: calendarId
+        description: Calendar identifier of the source calendar where the event currently
+          is on
+      - in: query
+        name: destination
+        description: Calendar identifier of the target calendar where the event is
+          to be moved to
+      - in: path
+        name: eventId
+        description: Event identifier
+      - in: query
+        name: sendNotifications
+        description: Whether to send notifications about the change of the event's
+          organizer
+      responses:
+        200:
+          description: OK
+      tags:
+      - Event
+  /channels/stop:
+    post:
+      summary: Stop Watching Resource
+      description: Stop watching resources through this channel
+      operationId: calendar.channels.stop
+      parameters:
+      - in: body
+        name: resource
+        schema:
+          $ref: '#/definitions/holder'
+      responses:
+        200:
+          description: OK
+      tags:
+      - Watch
+  /colors:
+    get:
+      summary: Get Colors
+      description: Returns the color definitions for calendars and events
+      operationId: calendar.colors.get
+      responses:
+        200:
+          description: OK
+      tags:
+      - Color
+  /freeBusy:
+    post:
+      summary: Return Free/Busy Information
+      description: Returns free/busy information for a set of calendars
+      operationId: calendar.freebusy.query
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      responses:
+        200:
+          description: OK
+      tags:
+      - Free/Busy
+  /users/me/calendarList:
+    get:
+      summary: Return Entries
+      description: Returns entries on the user's calendar list
+      operationId: calendar.calendarList.list
+      parameters:
+      - in: query
+        name: maxResults
+        description: Maximum number of entries returned on one result page
+      - in: query
+        name: minAccessRole
+        description: The minimum access role for the user in the returned entries
+      - in: query
+        name: pageToken
+        description: Token specifying which result page to return
+      - in: query
+        name: showDeleted
+        description: Whether to include deleted calendar list entries in the result
+      - in: query
+        name: showHidden
+        description: Whether to show hidden entries
+      - in: query
+        name: syncToken
+        description: Token obtained from the nextSyncToken field returned on the last
+          page of results from the previous list request
+      responses:
+        200:
+          description: OK
+      tags:
+      - Event
+    post:
+      summary: Add Entry
+      description: Adds an entry to the user's calendar list
+      operationId: calendar.calendarList.insert
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: query
+        name: colorRgbFormat
+        description: Whether to use the foregroundColor and backgroundColor fields
+          to write the calendar colors (RGB)
+      responses:
+        200:
+          description: OK
+      tags:
+      - Event
+  /users/me/calendarList/watch:
+    post:
+      summary: Watch Entry
+      description: Watch for changes to CalendarList resources
+      operationId: calendar.calendarList.watch
+      parameters:
+      - in: query
+        name: maxResults
+        description: Maximum number of entries returned on one result page
+      - in: query
+        name: minAccessRole
+        description: The minimum access role for the user in the returned entries
+      - in: query
+        name: pageToken
+        description: Token specifying which result page to return
+      - in: body
+        name: resource
+        schema:
+          $ref: '#/definitions/holder'
+      - in: query
+        name: showDeleted
+        description: Whether to include deleted calendar list entries in the result
+      - in: query
+        name: showHidden
+        description: Whether to show hidden entries
+      - in: query
+        name: syncToken
+        description: Token obtained from the nextSyncToken field returned on the last
+          page of results from the previous list request
+      responses:
+        200:
+          description: OK
+      tags:
+      - Event
+  /users/me/calendarList/{calendarId}:
+    delete:
+      summary: Delete Entry
+      description: Deletes an entry on the user's calendar list
+      operationId: calendar.calendarList.delete
+      parameters:
+      - in: path
+        name: calendarId
+        description: Calendar identifier
+      responses:
+        200:
+          description: OK
+      tags:
+      - Event
+    get:
+      summary: Get Entry
+      description: Returns an entry on the user's calendar list
+      operationId: calendar.calendarList.get
+      parameters:
+      - in: path
+        name: calendarId
+        description: Calendar identifier
+      responses:
+        200:
+          description: OK
+      tags:
+      - Event
+    patch:
+      summary: Update Entry
+      description: Updates an entry on the user's calendar list
+      operationId: calendar.calendarList.patch
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: path
+        name: calendarId
+        description: Calendar identifier
+      - in: query
+        name: colorRgbFormat
+        description: Whether to use the foregroundColor and backgroundColor fields
+          to write the calendar colors (RGB)
+      responses:
+        200:
+          description: OK
+      tags:
+      - Event
+    put:
+      summary: Update Entry
+      description: Updates an entry on the user's calendar list
+      operationId: calendar.calendarList.update
+      parameters:
+      - in: body
+        name: body
+        schema:
+          $ref: '#/definitions/holder'
+      - in: path
+        name: calendarId
+        description: Calendar identifier
+      - in: query
+        name: colorRgbFormat
+        description: Whether to use the foregroundColor and backgroundColor fields
+          to write the calendar colors (RGB)
+      responses:
+        200:
+          description: OK
+      tags:
+      - Event
+  /users/me/settings:
+    get:
+      summary: Get Settings
+      description: Returns all user settings for the authenticated user
+      operationId: calendar.settings.list
+      parameters:
+      - in: query
+        name: maxResults
+        description: Maximum number of entries returned on one result page
+      - in: query
+        name: pageToken
+        description: Token specifying which result page to return
+      - in: query
+        name: syncToken
+        description: Token obtained from the nextSyncToken field returned on the last
+          page of results from the previous list request
+      responses:
+        200:
+          description: OK
+      tags:
+      - Setting
+  /users/me/settings/watch:
+    post:
+      summary: Watch Settings
+      description: Watch for changes to Settings resources
+      operationId: calendar.settings.watch
+      parameters:
+      - in: query
+        name: maxResults
+        description: Maximum number of entries returned on one result page
+      - in: query
+        name: pageToken
+        description: Token specifying which result page to return
+      - in: body
+        name: resource
+        schema:
+          $ref: '#/definitions/holder'
+      - in: query
+        name: syncToken
+        description: Token obtained from the nextSyncToken field returned on the last
+          page of results from the previous list request
+      responses:
+        200:
+          description: OK
+      tags:
+      - Setting
+  /users/me/settings/{setting}:
+    get:
+      summary: Get Setting
+      description: Returns a single user setting
+      operationId: calendar.settings.get
+      parameters:
+      - in: path
+        name: setting
+        description: The id of the user setting
+      responses:
+        200:
+          description: OK
+      tags:
+      - Setting
+definitions:
+  Acl:
+    properties:
+      etag:
+        description: This is a default description.
+        type: parameters
+      items:
+        description: This is a default description.
+        type: parameters
+      kind:
+        description: This is a default description.
+        type: parameters
+      nextPageToken:
+        description: This is a default description.
+        type: parameters
+      nextSyncToken:
+        description: This is a default description.
+        type: parameters
+  AclRule:
+    properties:
+      etag:
+        description: This is a default description.
+        type: parameters
+      id:
+        description: This is a default description.
+        type: parameters
+      kind:
+        description: This is a default description.
+        type: parameters
+      role:
+        description: This is a default description.
+        type: parameters
+      scope:
+        description: This is a default description.
+        type: parameters
+  Calendar:
+    properties:
+      description:
+        description: This is a default description.
+        type: parameters
+      etag:
+        description: This is a default description.
+        type: parameters
+      id:
+        description: This is a default description.
+        type: parameters
+      kind:
+        description: This is a default description.
+        type: parameters
+      location:
+        description: This is a default description.
+        type: parameters
+      summary:
+        description: This is a default description.
+        type: parameters
+      timeZone:
+        description: This is a default description.
+        type: parameters
+  CalendarList:
+    properties:
+      etag:
+        description: This is a default description.
+        type: parameters
+      items:
+        description: This is a default description.
+        type: parameters
+      kind:
+        description: This is a default description.
+        type: parameters
+      nextPageToken:
+        description: This is a default description.
+        type: parameters
+      nextSyncToken:
+        description: This is a default description.
+        type: parameters
+  CalendarListEntry:
+    properties:
+      accessRole:
+        description: This is a default description.
+        type: parameters
+      backgroundColor:
+        description: This is a default description.
+        type: parameters
+      colorId:
+        description: This is a default description.
+        type: parameters
+      defaultReminders:
+        description: This is a default description.
+        type: parameters
+      deleted:
+        description: This is a default description.
+        type: parameters
+      description:
+        description: This is a default description.
+        type: parameters
+      etag:
+        description: This is a default description.
+        type: parameters
+      foregroundColor:
+        description: This is a default description.
+        type: parameters
+      hidden:
+        description: This is a default description.
+        type: parameters
+      id:
+        description: This is a default description.
+        type: parameters
+      kind:
+        description: This is a default description.
+        type: parameters
+      location:
+        description: This is a default description.
+        type: parameters
+      notificationSettings:
+        description: This is a default description.
+        type: parameters
+      primary:
+        description: This is a default description.
+        type: parameters
+      selected:
+        description: This is a default description.
+        type: parameters
+      summary:
+        description: This is a default description.
+        type: parameters
+      summaryOverride:
+        description: This is a default description.
+        type: parameters
+      timeZone:
+        description: This is a default description.
+        type: parameters
+  CalendarNotification:
+    properties:
+      method:
+        description: This is a default description.
+        type: parameters
+      type:
+        description: This is a default description.
+        type: parameters
+  Channel:
+    properties:
+      address:
+        description: This is a default description.
+        type: parameters
+      expiration:
+        description: This is a default description.
+        type: parameters
+      id:
+        description: This is a default description.
+        type: parameters
+      kind:
+        description: This is a default description.
+        type: parameters
+      params:
+        description: This is a default description.
+        type: parameters
+      payload:
+        description: This is a default description.
+        type: parameters
+      resourceId:
+        description: This is a default description.
+        type: parameters
+      resourceUri:
+        description: This is a default description.
+        type: parameters
+      token:
+        description: This is a default description.
+        type: parameters
+      type:
+        description: This is a default description.
+        type: parameters
+  ColorDefinition:
+    properties:
+      background:
+        description: This is a default description.
+        type: parameters
+      foreground:
+        description: This is a default description.
+        type: parameters
+  Colors:
+    properties:
+      calendar:
+        description: This is a default description.
+        type: parameters
+      event:
+        description: This is a default description.
+        type: parameters
+      kind:
+        description: This is a default description.
+        type: parameters
+      updated:
+        description: This is a default description.
+        type: parameters
+  Error:
+    properties:
+      domain:
+        description: This is a default description.
+        type: parameters
+      reason:
+        description: This is a default description.
+        type: parameters
+  Event:
+    properties:
+      anyoneCanAddSelf:
+        description: This is a default description.
+        type: parameters
+      attachments:
+        description: This is a default description.
+        type: parameters
+      attendees:
+        description: This is a default description.
+        type: parameters
+      attendeesOmitted:
+        description: This is a default description.
+        type: parameters
+      colorId:
+        description: This is a default description.
+        type: parameters
+      created:
+        description: This is a default description.
+        type: parameters
+      creator:
+        description: This is a default description.
+        type: parameters
+      description:
+        description: This is a default description.
+        type: parameters
+      endTimeUnspecified:
+        description: This is a default description.
+        type: parameters
+      etag:
+        description: This is a default description.
+        type: parameters
+      extendedProperties:
+        description: This is a default description.
+        type: parameters
+      gadget:
+        description: This is a default description.
+        type: parameters
+      guestsCanInviteOthers:
+        description: This is a default description.
+        type: parameters
+      guestsCanModify:
+        description: This is a default description.
+        type: parameters
+      guestsCanSeeOtherGuests:
+        description: This is a default description.
+        type: parameters
+      hangoutLink:
+        description: This is a default description.
+        type: parameters
+      htmlLink:
+        description: This is a default description.
+        type: parameters
+      iCalUID:
+        description: This is a default description.
+        type: parameters
+      id:
+        description: This is a default description.
+        type: parameters
+      kind:
+        description: This is a default description.
+        type: parameters
+      location:
+        description: This is a default description.
+        type: parameters
+      locked:
+        description: This is a default description.
+        type: parameters
+      organizer:
+        description: This is a default description.
+        type: parameters
+      privateCopy:
+        description: This is a default description.
+        type: parameters
+      recurrence:
+        description: This is a default description.
+        type: parameters
+      recurringEventId:
+        description: This is a default description.
+        type: parameters
+      reminders:
+        description: This is a default description.
+        type: parameters
+      sequence:
+        description: This is a default description.
+        type: parameters
+      source:
+        description: This is a default description.
+        type: parameters
+      status:
+        description: This is a default description.
+        type: parameters
+      summary:
+        description: This is a default description.
+        type: parameters
+      transparency:
+        description: This is a default description.
+        type: parameters
+      updated:
+        description: This is a default description.
+        type: parameters
+      visibility:
+        description: This is a default description.
+        type: parameters
+  EventAttachment:
+    properties:
+      fileId:
+        description: This is a default description.
+        type: parameters
+      fileUrl:
+        description: This is a default description.
+        type: parameters
+      iconLink:
+        description: This is a default description.
+        type: parameters
+      mimeType:
+        description: This is a default description.
+        type: parameters
+      title:
+        description: This is a default description.
+        type: parameters
+  EventAttendee:
+    properties:
+      additionalGuests:
+        description: This is a default description.
+        type: parameters
+      comment:
+        description: This is a default description.
+        type: parameters
+      displayName:
+        description: This is a default description.
+        type: parameters
+      email:
+        description: This is a default description.
+        type: parameters
+      id:
+        description: This is a default description.
+        type: parameters
+      optional:
+        description: This is a default description.
+        type: parameters
+      organizer:
+        description: This is a default description.
+        type: parameters
+      resource:
+        description: This is a default description.
+        type: parameters
+      responseStatus:
+        description: This is a default description.
+        type: parameters
+      self:
+        description: This is a default description.
+        type: parameters
+  EventDateTime:
+    properties:
+      date:
+        description: This is a default description.
+        type: parameters
+      dateTime:
+        description: This is a default description.
+        type: parameters
+      timeZone:
+        description: This is a default description.
+        type: parameters
+  EventReminder:
+    properties:
+      method:
+        description: This is a default description.
+        type: parameters
+      minutes:
+        description: This is a default description.
+        type: parameters
+  Events:
+    properties:
+      accessRole:
+        description: This is a default description.
+        type: parameters
+      defaultReminders:
+        description: This is a default description.
+        type: parameters
+      description:
+        description: This is a default description.
+        type: parameters
+      etag:
+        description: This is a default description.
+        type: parameters
+      items:
+        description: This is a default description.
+        type: parameters
+      kind:
+        description: This is a default description.
+        type: parameters
+      nextPageToken:
+        description: This is a default description.
+        type: parameters
+      nextSyncToken:
+        description: This is a default description.
+        type: parameters
+      summary:
+        description: This is a default description.
+        type: parameters
+      timeZone:
+        description: This is a default description.
+        type: parameters
+      updated:
+        description: This is a default description.
+        type: parameters
+  FreeBusyCalendar:
+    properties:
+      busy:
+        description: This is a default description.
+        type: parameters
+      errors:
+        description: This is a default description.
+        type: parameters
+  FreeBusyGroup:
+    properties:
+      calendars:
+        description: This is a default description.
+        type: parameters
+      errors:
+        description: This is a default description.
+        type: parameters
+  FreeBusyRequest:
+    properties:
+      calendarExpansionMax:
+        description: This is a default description.
+        type: parameters
+      groupExpansionMax:
+        description: This is a default description.
+        type: parameters
+      items:
+        description: This is a default description.
+        type: parameters
+      timeMax:
+        description: This is a default description.
+        type: parameters
+      timeMin:
+        description: This is a default description.
+        type: parameters
+      timeZone:
+        description: This is a default description.
+        type: parameters
+  FreeBusyRequestItem:
+    properties:
+      id:
+        description: This is a default description.
+        type: parameters
+  FreeBusyResponse:
+    properties:
+      calendars:
+        description: This is a default description.
+        type: parameters
+      groups:
+        description: This is a default description.
+        type: parameters
+      kind:
+        description: This is a default description.
+        type: parameters
+      timeMax:
+        description: This is a default description.
+        type: parameters
+      timeMin:
+        description: This is a default description.
+        type: parameters
+  Setting:
+    properties:
+      etag:
+        description: This is a default description.
+        type: parameters
+      id:
+        description: This is a default description.
+        type: parameters
+      kind:
+        description: This is a default description.
+        type: parameters
+      value:
+        description: This is a default description.
+        type: parameters
+  Settings:
+    properties:
+      etag:
+        description: This is a default description.
+        type: parameters
+      items:
+        description: This is a default description.
+        type: parameters
+      kind:
+        description: This is a default description.
+        type: parameters
+      nextPageToken:
+        description: This is a default description.
+        type: parameters
+      nextSyncToken:
+        description: This is a default description.
+        type: parameters
+  TimePeriod:
+    properties:
+      end:
+        description: This is a default description.
+        type: parameters
+      start:
+        description: This is a default description.
+        type: parameters

--- a/src/mcp_gsuite/calendar.py
+++ b/src/mcp_gsuite/calendar.py
@@ -6,13 +6,43 @@ from datetime import datetime
 import pytz
 
 class CalendarService():
-    def __init__(self):
-        credentials = gauth.get_stored_credentials()
+    def __init__(self, user_id: str):
+        credentials = gauth.get_stored_credentials(user_id=user_id)
         if not credentials:
             raise RuntimeError("No Oauth2 credentials stored")
         self.service = build('calendar', 'v3', credentials=credentials)  # Note: using v3 for Calendar API
+    
+    def list_calendars(self) -> list:
+        """
+        Lists all calendars accessible by the user.
         
-    def get_events(self, time_min=None, time_max=None, max_results=250, show_deleted=False):
+        Returns:
+            list: List of calendar objects with their metadata
+        """
+        try:
+            calendar_list = self.service.calendarList().list().execute()
+
+            calendars = []
+            
+            for calendar in calendar_list.get('items', []):
+                if calendar.get('kind') == 'calendar#calendarListEntry':
+                    calendars.append({
+                        'id': calendar.get('id'),
+                        'summary': calendar.get('summary'),
+                        'primary': calendar.get('primary', False),
+                        'time_zone': calendar.get('timeZone'),
+                        'etag': calendar.get('etag'),
+                        'access_role': calendar.get('accessRole')
+                    })
+
+            return calendars
+                
+        except Exception as e:
+            logging.error(f"Error retrieving calendars: {str(e)}")
+            logging.error(traceback.format_exc())
+            return []
+
+    def get_events(self, time_min=None, time_max=None, max_results=250, show_deleted=False, calendar_id: str ='primary'):
         """
         Retrieve calendar events within a specified time range.
         
@@ -35,7 +65,7 @@ class CalendarService():
             
             # Prepare parameters
             params = {
-                'calendarId': 'primary',
+                'calendarId': calendar_id,
                 'timeMin': time_min,
                 'maxResults': max_results,
                 'singleEvents': True,
@@ -83,7 +113,8 @@ class CalendarService():
     def create_event(self, summary: str, start_time: str, end_time: str, 
                 location: str = None, description: str = None, 
                 attendees: list = None, send_notifications: bool = True,
-                timezone: str = None) -> dict:
+                timezone: str = None,
+                calendar_id : str = 'primary') -> dict:
         """
         Create a new calendar event.
         
@@ -124,7 +155,7 @@ class CalendarService():
                 
             # Create the event
             created_event = self.service.events().insert(
-                calendarId='primary',
+                calendarId=calendar_id,
                 body=event,
                 sendNotifications=send_notifications
             ).execute()
@@ -136,7 +167,7 @@ class CalendarService():
             logging.error(traceback.format_exc())
             return None
         
-    def delete_event(self, event_id: str, send_notifications: bool = True) -> bool:
+    def delete_event(self, event_id: str, send_notifications: bool = True, calendar_id: str = 'primary') -> bool:
         """
         Delete a calendar event by its ID.
         
@@ -149,7 +180,7 @@ class CalendarService():
         """
         try:
             self.service.events().delete(
-                calendarId='primary',
+                calendarId=calendar_id,
                 eventId=event_id,
                 sendNotifications=send_notifications
             ).execute()

--- a/src/mcp_gsuite/gmail.py
+++ b/src/mcp_gsuite/gmail.py
@@ -7,8 +7,8 @@ from email.mime.text import MIMEText
 
 
 class GmailService():
-    def __init__(self):
-        credentials = gauth.get_stored_credentials()
+    def __init__(self, user_id: str):
+        credentials = gauth.get_stored_credentials(user_id=user_id)
         if not credentials:
             raise RuntimeError("No Oauth2 credentials stored")
         self.service = build('gmail', 'v1', credentials=credentials)
@@ -83,24 +83,34 @@ class GmailService():
     def _extract_body(self, payload) -> str | None:
         """
         Extract the email body from the payload.
-        Handles both multipart and single part messages.
+        Handles both multipart and single part messages, including nested multiparts.
         """
         try:
+            # For single part text/plain messages
             if payload.get('mimeType') == 'text/plain':
                 data = payload.get('body', {}).get('data')
                 if data:
                     return base64.urlsafe_b64decode(data).decode('utf-8')
-                
-            elif payload.get('mimeType') == 'multipart/alternative':
+            
+            # For multipart messages (both alternative and related)
+            if payload.get('mimeType', '').startswith('multipart/'):
                 parts = payload.get('parts', [])
-                # Try to find text/plain part first
+                
+                # First try to find a direct text/plain part
                 for part in parts:
                     if part.get('mimeType') == 'text/plain':
                         data = part.get('body', {}).get('data')
                         if data:
                             return base64.urlsafe_b64decode(data).decode('utf-8')
+                
+                # If no direct text/plain, recursively check nested multipart structures
+                for part in parts:
+                    if part.get('mimeType', '').startswith('multipart/'):
+                        nested_body = self._extract_body(part)
+                        if nested_body:
+                            return nested_body
                             
-                # Fall back to first part if no text/plain found
+                # If still no body found, try the first part as fallback
                 if parts and 'body' in parts[0] and 'data' in parts[0]['body']:
                     data = parts[0]['body']['data']
                     return base64.urlsafe_b64decode(data).decode('utf-8')

--- a/src/mcp_gsuite/toolhandler.py
+++ b/src/mcp_gsuite/toolhandler.py
@@ -6,10 +6,25 @@ from mcp.types import (
     EmbeddedResource,
 )
 
+import os
+
+USER_ID_ARG = "__user_id__"
 
 class ToolHandler():
     def __init__(self, tool_name: str):
         self.name = tool_name
+
+    def get_supported_emails(self) -> list[str]:
+        return os.getenv("GOOGLE_EMAILS").split(":")
+    
+    def get_supported_emails_tool_text(self) -> str:
+        return f"""This tool requires a authorized google email for {USER_ID_ARG} argument. You can choose one of: {', '.join(self.get_supported_emails())}"""
+
+    def get_user_id_arg_schema(self) -> dict:
+        return {
+            "type": "string",
+            "description": f"The EMAIL of the google account for which you are executing this action. Can be one of: {', '.join(self.get_supported_emails())}"
+        }
 
     def get_tool_description(self) -> Tool:
         raise NotImplementedError()

--- a/src/mcp_gsuite/tools_gmail.py
+++ b/src/mcp_gsuite/tools_gmail.py
@@ -11,31 +11,8 @@ from . import gmail
 import json
 from . import toolhandler
 
-class GetUserInfoToolHandler(toolhandler.ToolHandler):
-    def __init__(self):
-        super().__init__("get_gmail_user_info")
 
-    def get_tool_description(self) -> Tool:
-        return Tool(
-           name=self.name,
-           description="""Returns the gmail user info.""",
-           inputSchema={
-               "type": "object",
-               "properties": {},
-               "required": []
-           }
-       )
 
-    def run_tool(self, args: dict) -> Sequence[TextContent | ImageContent | EmbeddedResource]:
-        credentials = gauth.get_stored_credentials()
-        user_info = gauth.get_user_info(credentials=credentials)
-        return [
-            TextContent(
-                type="text",
-                text=json.dumps(user_info, indent=2)
-            )
-        ]
-    
 class QueryEmailsToolHandler(toolhandler.ToolHandler):
     def __init__(self):
         super().__init__("query_gmail_emails")
@@ -50,6 +27,7 @@ class QueryEmailsToolHandler(toolhandler.ToolHandler):
             inputSchema={
                 "type": "object",
                 "properties": {
+                    "__user_id__": self.get_user_id_arg_schema(),
                     "query": {
                         "type": "string",
                         "description": """Gmail search query (optional). Examples:
@@ -69,12 +47,17 @@ class QueryEmailsToolHandler(toolhandler.ToolHandler):
                         "default": 100
                     }
                 },
-                "required": []
+                "required": [toolhandler.USER_ID_ARG]
             }
         )
 
     def run_tool(self, args: dict) -> Sequence[TextContent | ImageContent | EmbeddedResource]:
-        gmail_service = gmail.GmailService()
+
+        user_id = args.get(toolhandler.USER_ID_ARG)
+        if not user_id:
+            raise RuntimeError(f"Missing required argument: {toolhandler.USER_ID_ARG}")
+
+        gmail_service = gmail.GmailService(user_id=user_id)
         query = args.get('query')
         max_results = args.get('max_results', 100)
         emails = gmail_service.query_emails(query=query, max_results=max_results)
@@ -97,12 +80,13 @@ class GetEmailByIdToolHandler(toolhandler.ToolHandler):
             inputSchema={
                 "type": "object",
                 "properties": {
+                    "__user_id__": self.get_user_id_arg_schema(),
                     "email_id": {
                         "type": "string",
                         "description": "The ID of the Gmail message to retrieve"
                     }
                 },
-                "required": ["email_id"]
+                "required": ["email_id", toolhandler.USER_ID_ARG]
             }
         )
 
@@ -110,7 +94,10 @@ class GetEmailByIdToolHandler(toolhandler.ToolHandler):
         if "email_id" not in args:
             raise RuntimeError("Missing required argument: email_id")
 
-        gmail_service = gmail.GmailService()
+        user_id = args.get(toolhandler.USER_ID_ARG)
+        if not user_id:
+            raise RuntimeError(f"Missing required argument: {toolhandler.USER_ID_ARG}")
+        gmail_service = gmail.GmailService(user_id=user_id)
         email = gmail_service.get_email_by_id(args["email_id"])
 
         if email is None:
@@ -144,6 +131,7 @@ class CreateDraftToolHandler(toolhandler.ToolHandler):
             inputSchema={
                 "type": "object",
                 "properties": {
+                    "__user_id__": self.get_user_id_arg_schema(),
                     "to": {
                         "type": "string",
                         "description": "Email address of the recipient"
@@ -164,7 +152,7 @@ class CreateDraftToolHandler(toolhandler.ToolHandler):
                         "description": "Optional list of email addresses to CC"
                     }
                 },
-                "required": ["to", "subject", "body"]
+                "required": ["to", "subject", "body", toolhandler.USER_ID_ARG]
             }
         )
 
@@ -173,7 +161,10 @@ class CreateDraftToolHandler(toolhandler.ToolHandler):
         if not all(key in args for key in required):
             raise RuntimeError(f"Missing required arguments: {', '.join(required)}")
 
-        gmail_service = gmail.GmailService()
+        user_id = args.get(toolhandler.USER_ID_ARG)
+        if not user_id:
+            raise RuntimeError(f"Missing required argument: {toolhandler.USER_ID_ARG}")
+        gmail_service = gmail.GmailService(user_id=user_id)
         draft = gmail_service.create_draft(
             to=args["to"],
             subject=args["subject"],
@@ -207,12 +198,13 @@ class DeleteDraftToolHandler(toolhandler.ToolHandler):
             inputSchema={
                 "type": "object",
                 "properties": {
+                    "__user_id__": self.get_user_id_arg_schema(),
                     "draft_id": {
                         "type": "string",
                         "description": "The ID of the draft to delete"
                     }
                 },
-                "required": ["draft_id"]
+                "required": ["draft_id", toolhandler.USER_ID_ARG]
             }
         )
 
@@ -220,7 +212,10 @@ class DeleteDraftToolHandler(toolhandler.ToolHandler):
         if "draft_id" not in args:
             raise RuntimeError("Missing required argument: draft_id")
 
-        gmail_service = gmail.GmailService()
+        user_id = args.get(toolhandler.USER_ID_ARG)
+        if not user_id:
+            raise RuntimeError(f"Missing required argument: {toolhandler.USER_ID_ARG}")
+        gmail_service = gmail.GmailService(user_id=user_id)
         success = gmail_service.delete_draft(args["draft_id"])
 
         return [
@@ -241,6 +236,7 @@ class ReplyEmailToolHandler(toolhandler.ToolHandler):
             inputSchema={
                 "type": "object",
                 "properties": {
+                    "__user_id__": self.get_user_id_arg_schema(),
                     "original_message_id": {
                         "type": "string",
                         "description": "The ID of the Gmail message to reply to"
@@ -262,7 +258,7 @@ class ReplyEmailToolHandler(toolhandler.ToolHandler):
                         "description": "Optional list of email addresses to CC on the reply"
                     }
                 },
-                "required": ["original_message_id", "reply_body"]
+                "required": ["original_message_id", "reply_body", toolhandler.USER_ID_ARG]
             }
         )
 
@@ -270,7 +266,10 @@ class ReplyEmailToolHandler(toolhandler.ToolHandler):
         if not all(key in args for key in ["original_message_id", "reply_body"]):
             raise RuntimeError("Missing required arguments: original_message_id and reply_body")
 
-        gmail_service = gmail.GmailService()
+        user_id = args.get(toolhandler.USER_ID_ARG)
+        if not user_id:
+            raise RuntimeError(f"Missing required argument: {toolhandler.USER_ID_ARG}")
+        gmail_service = gmail.GmailService(user_id=user_id)
         
         # First get the original message to extract necessary information
         original_message = gmail_service.get_email_by_id(args["original_message_id"])


### PR DESCRIPTION
# Add Support for Multiple Google Accounts and Streamline Calendar Listing

## Changes
- Added support for multiple Google accounts in MCP server configuration
- Implemented new `list_calendars` endpoint to retrieve core calendar information
- Streamlined calendar data output to include essential fields only
- All calls to gmail API now require `__user_id__`
- All calls to calendar API now require `__user_id__` and optionally accept `__calendar_id__`

## Calendar API Changes

### New List Calendars Handler
Added `ListCalendarsToolHandler` to query available calendars with minimal metadata:
- Calendar ID 
- Display name (summary)
- Primary calendar flag
- Timezone

### Simplified Response Format
Modified `list_calendars()` to return focused data structure:
```python
{
 "id": "calendar_id",
 "summary": "Calendar Name",
 "primary": true|false,
 "timeZone": "Europe/Amsterdam"
}