### PR TITLE
Add Smithery badge and installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # mcp-gsuite MCP server
 
+[![smithery badge](https://smithery.ai/badge/mcp-gsuite)](https://smithery.ai/protocol/mcp-gsuite)
 MCP server to interact with Google produts.
 
 ## Example prompts
@@ -44,6 +45,14 @@ Example prompts you can try:
 ## Quickstart
 
 ### Install
+
+### Installing via Smithery
+
+To install mcp-gsuite for Claude Desktop automatically via [Smithery](https://smithery.ai/protocol/mcp-gsuite):
+
+```bash
+npx @smithery/cli install mcp-gsuite --client claude
+```
 
 #### Oauth 2
 


### PR DESCRIPTION
This PR adds installation instructions to automatically install [NAME] for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP. Also, it adds a badge to show the number of installations from Smithery.