### PR TITLE
Fix: Upgrade MCP library to v1.3.0 for request cancellation support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
  "beautifulsoup4>=4.12.3",
  "google-api-python-client>=2.154.0",
  "httplib2>=0.22.0",
- "mcp>=1.1.0",
+ "mcp>=1.3.0",
  "oauth2client==4.1.3",
  "python-dotenv>=1.0.1",
  "pytz>=2024.2",


### PR DESCRIPTION
## Description
This PR upgrades the MCP library dependency from v1.1.0 to v1.3.0 to add support for request cancellation notifications.

## Related Issue
Fixes #21

## Changes
- Updated MCP dependency in pyproject.toml from v1.1.0 to v1.3.0

## Why
The MCP-GSuite server crashes when it receives a `notifications/cancelled` notification, which happens when a request times out. MCP v1.3.0 added support for this notification type in [modelcontextprotocol/python-sdk#167](https://github.com/modelcontextprotocol/python-sdk/pull/167).