### PR TITLE
Fix KeyError 'parts' when handling emails without attachments

### DIFF
--- a/src/mcp_gsuite/gmail.py
+++ b/src/mcp_gsuite/gmail.py
@@ -190,7 +190,7 @@ class GmailService():
                 return None, []
 
             attachments = {}
-            for part in message["payload"]["parts"]:
+            for part in message["payload"].get("parts", []):
                 if "attachmentId" in part["body"]:
                     attachment_id = part["body"]["attachmentId"]
                     part_id = part["partId"]


### PR DESCRIPTION
## Description
This PR addresses an issue where the `get_email_by_id_with_attachments` function crashes with a `KeyError: 'parts'` when processing emails that don't have any attachments in their payload structure.

### Problem
When the Gmail API returns a message without attachments, the message payload may not contain a "parts" key. The current code attempts to access `message["payload"]["parts"]` directly, which raises a KeyError if "parts" doesn't exist.

### Solution
Modified the code to use the dictionary's `.get()` method with an empty list as the default value:
```python
for part in message["payload"].get("parts", []):
```

This ensures that when the "parts" key doesn't exist, the function safely continues execution with an empty list instead of crashing.

### Logs
Before the fix:
```
ERROR:root:Error retrieving email 195ef10e8d42ae30: 'parts'
ERROR:root:Traceback (most recent call last):
  File "/Users/ssilver/MCPs/mcp-gsuite/src/mcp_gsuite/gmail.py", line 193, in get_email_by_id_with_attachments
    for part in message["payload"].get("parts", []):
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'parts'
```