### PR TITLE
Remove invalid JSON schema in query gmail emails tool

### DIFF
--- a/src/mcp_gsuite/tools_gmail.py
+++ b/src/mcp_gsuite/tools_gmail.py
@@ -42,7 +42,6 @@ class QueryEmailsToolHandler(toolhandler.ToolHandler):
                             - 'newer_than:2d' for emails from last 2 days
                             - 'has:attachment' for emails with attachments
                             If not provided, returns recent emails without filtering.""",
-                        "required": False
                     },
                     "max_results": {
                         "type": "integer",


### PR DESCRIPTION
Resolves this error returned by the OpenAI API:
{'error': {'message': \"Invalid schema for function 'google-suite__query_gmail_emails': False is not of type 'array'.\", 'type': 'invalid_request_error', 'param': 'tools[5].function.parameters', 'code': 'invalid_function_parameters'}