### PR TITLE
support calendar list colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Right now, this MCP server supports Gmail and Calendar integration with the foll
   + Custom timezone support
   + Notification preferences
 * Delete calendar events
+* List calendar colors
 
 Example prompts you can try:
 
@@ -121,7 +122,7 @@ On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
 
 <details>
   <summary>Development/Unpublished Servers Configuration</summary>
-  
+
 
 ```json
 {
@@ -166,7 +167,7 @@ Note: You can also use the `uv run mcp-gsuite --accounts-file /path/to/custom/.a
 
 <details>
   <summary>Published Servers Configuration</summary>
-  
+
 
 ```json
 {

--- a/src/mcp_gsuite/calendar.py
+++ b/src/mcp_gsuite/calendar.py
@@ -190,3 +190,19 @@ class CalendarService():
             logging.error(f"Error deleting calendar event {event_id}: {str(e)}")
             logging.error(traceback.format_exc())
             return False
+
+    def list_colors(self) -> dict | None:
+        """
+        Lists the available colors for calendar and events.
+
+        Returns:
+            dict: A dictionary containing 'event' and 'calendar' color definitions if successful.
+            None: If an error occurred.
+        """
+        try:
+            colors = self.service.colors().get().execute()
+            return colors
+        except Exception as e:
+            logging.error("Error while listing colors:")
+            logging.error(traceback.format_exc())
+            return None

--- a/src/mcp_gsuite/server.py
+++ b/src/mcp_gsuite/server.py
@@ -51,6 +51,7 @@ class OauthListener(BaseHTTPRequestHandler):
 
         
 
+
 load_dotenv()
 
 from . import tools_gmail
@@ -72,8 +73,7 @@ def start_auth_flow(user_id: str):
         import webbrowser
         webbrowser.open(auth_url)
 
-    # start server for code callback
-    server_address = ('', 4100)
+    server_address = ('', gauth.extract_redirect_uri_port())
     server = HTTPServer(server_address, OauthListener)
     server.serve_forever()
 

--- a/src/mcp_gsuite/server.py
+++ b/src/mcp_gsuite/server.py
@@ -109,7 +109,7 @@ def add_tool_handler(tool_class: toolhandler.ToolHandler):
 def get_tool_handler(name: str) -> toolhandler.ToolHandler | None:
     if name not in tool_handlers:
         return None
-    
+
     return tool_handlers[name]
 
 add_tool_handler(tools_gmail.QueryEmailsToolHandler())
@@ -125,6 +125,7 @@ add_tool_handler(tools_calendar.ListCalendarsToolHandler())
 add_tool_handler(tools_calendar.GetCalendarEventsToolHandler())
 add_tool_handler(tools_calendar.CreateCalendarEventToolHandler())
 add_tool_handler(tools_calendar.DeleteCalendarEventToolHandler())
+add_tool_handler(tools_calendar.ListCalendarEventColorToolHandler())
 
 @app.list_tools()
 async def list_tools() -> list[Tool]:
@@ -135,10 +136,10 @@ async def list_tools() -> list[Tool]:
 
 @app.call_tool()
 async def call_tool(name: str, arguments: Any) -> Sequence[TextContent | ImageContent | EmbeddedResource]:
-    try:        
+    try:
         if not isinstance(arguments, dict):
             raise RuntimeError("arguments must be dictionary")
-        
+
         if toolhandler.USER_ID_ARG not in arguments:
             raise RuntimeError("user_id argument is missing in dictionary.")
 
@@ -156,7 +157,7 @@ async def call_tool(name: str, arguments: Any) -> Sequence[TextContent | ImageCo
 
 
 async def main():
-    print(sys.platform)
+    logging.info(f"Platform: {sys.platform}")
     accounts = gauth.get_account_info()
     for account in accounts:
         creds = gauth.get_stored_credentials(user_id=account.email)

--- a/src/mcp_gsuite/tools_calendar.py
+++ b/src/mcp_gsuite/tools_calendar.py
@@ -17,8 +17,8 @@ def get_calendar_id_arg_schema() -> dict[str, str]:
     return {
         "type": "string",
         "description": """Optional ID of the specific agenda for which you are executing this action.
-                          If not provided, the default calendar is being used. 
-                          If not known, the specific calendar id can be retrieved with the list_calendars tool""",
+                        If not provided, the default calendar is being used.
+                        If not known, the specific calendar id can be retrieved with the list_calendars tool""",
         "default": "primary"
     }
 
@@ -30,7 +30,7 @@ class ListCalendarsToolHandler(toolhandler.ToolHandler):
     def get_tool_description(self) -> Tool:
         return Tool(
             name=self.name,
-            description="""Lists all calendars accessible by the user. 
+            description="""Lists all calendars accessible by the user.
             Call it before any other tool whenever the user specifies a particular agenda (Family, Holidays, etc.).""",
             inputSchema={
                 "type": "object",
@@ -74,7 +74,7 @@ class GetCalendarEventsToolHandler(toolhandler.ToolHandler):
                         "description": "Start time in RFC3339 format (e.g. 2024-12-01T00:00:00Z). Defaults to current time if not specified."
                     },
                     "time_max": {
-                        "type": "string", 
+                        "type": "string",
                         "description": "End time in RFC3339 format (e.g. 2024-12-31T23:59:59Z). Optional."
                     },
                     "max_results": {
@@ -95,11 +95,11 @@ class GetCalendarEventsToolHandler(toolhandler.ToolHandler):
         )
 
     def run_tool(self, args: dict) -> Sequence[TextContent | ImageContent | EmbeddedResource]:
-        
+
         user_id = args.get(toolhandler.USER_ID_ARG)
         if not user_id:
             raise RuntimeError(f"Missing required argument: {toolhandler.USER_ID_ARG}")
-        
+
         calendar_service = calendar.CalendarService(user_id=user_id)
         events = calendar_service.get_events(
             time_min=args.get('time_min'),
@@ -199,7 +199,7 @@ class CreateCalendarEventToolHandler(toolhandler.ToolHandler):
                 text=json.dumps(event, indent=2)
             )
         ]
-    
+
 class DeleteCalendarEventToolHandler(toolhandler.ToolHandler):
     def __init__(self):
         super().__init__("delete_calendar_event")
@@ -230,7 +230,7 @@ class DeleteCalendarEventToolHandler(toolhandler.ToolHandler):
     def run_tool(self, args: dict) -> Sequence[TextContent | ImageContent | EmbeddedResource]:
         if "event_id" not in args:
             raise RuntimeError("Missing required argument: event_id")
-        
+
         user_id = args.get(toolhandler.USER_ID_ARG)
         if not user_id:
             raise RuntimeError(f"Missing required argument: {toolhandler.USER_ID_ARG}")
@@ -249,5 +249,38 @@ class DeleteCalendarEventToolHandler(toolhandler.ToolHandler):
                     "success": success,
                     "message": "Event successfully deleted" if success else "Failed to delete event"
                 }, indent=2)
+            )
+        ]
+
+class ListCalendarEventColorToolHandler(toolhandler.ToolHandler):
+    def __init__(self):
+        super().__init__("list_calendar_event_color")
+
+    def get_tool_description(self) -> Tool:
+        return Tool(
+            name=self.name,
+            description="Lists available event colors from the user's Google Calendar by its event ID.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "__user_id__": self.get_user_id_arg_schema()
+                },
+                "required": [toolhandler.USER_ID_ARG]
+            }
+        )
+
+    def run_tool(self, args: dict) -> Sequence[TextContent | ImageContent | EmbeddedResource]:
+        user_id = args.get(toolhandler.USER_ID_ARG)
+
+        if not user_id:
+            raise RuntimeError(f"Missing required argument: {toolhandler.USER_ID_ARG}")
+
+        calendar_service = calendar.CalendarService(user_id=user_id)
+        colors = calendar_service.list_colors()
+
+        return [
+            TextContent(
+                type="text",
+                text=json.dumps(colors, indent=2)
             )
         ]


### PR DESCRIPTION
**Features**

feat: Implemented Google Calendar List Color API spec

- Implemented Google Calendar List Color API from gsuite library
- Modified README.md for supporting Calendar List Color tool function.

Support this API: https://developers.google.com/workspace/calendar/api/v3/reference/colors

**Tool Hanlders**

add_tool_handler(tools_calendar.ListCalendarEventColorToolHandler())

**Enhancements**

- Currently, REDIRECT_URI is hardcode from gauth.py, this commit attempts to read the port number from the .gauth.json file to avoid hard-coding it in server.py and google redirect flow accordingly.
