### PR TITLE
Fix invalid JSON Schema: remove "required": False from property definition

### DIFF
--- a/src/mcp_gsuite/tools_gmail.py
+++ b/src/mcp_gsuite/tools_gmail.py
@@ -41,8 +41,7 @@ class QueryEmailsToolHandler(toolhandler.ToolHandler):
                             - 'from:example@gmail.com' for emails from a specific sender
                             - 'newer_than:2d' for emails from last 2 days
                             - 'has:attachment' for emails with attachments
-                            If not provided, returns recent emails without filtering.""",
-                        "required": False
+                            If not provided, returns recent emails without filtering."""
                     },
                     "max_results": {
                         "type": "integer",


### PR DESCRIPTION
## Summary
- Removes `"required": False` from the `query` property definition in `QueryEmailsToolHandler.get_tool_description()`
- In JSON Schema, `required` is an object-level keyword (an array of property names), not a property-level boolean
- This caused schema validation errors in MCP clients that validate tool input schemas against the JSON Schema metaschema

The `query` parameter is already correctly optional by its absence from the object-level `"required"` array.

**Error seen by clients:**
```
False is not of type 'array'
Failed validating 'type' in metaschema['allOf'][1]['properties']['properties']['additionalProperties']['$dynamicRef']['allOf'][3]['properties']['required']
```

Fixes #48, fixes #50.