### PR TITLE
fix: remove invalid required: false from query property schema

### DIFF
--- a/src/mcp_gsuite/tools_gmail.py
+++ b/src/mcp_gsuite/tools_gmail.py
@@ -42,7 +42,7 @@ class QueryEmailsToolHandler(toolhandler.ToolHandler):
                             - 'newer_than:2d' for emails from last 2 days
                             - 'has:attachment' for emails with attachments
                             If not provided, returns recent emails without filtering.""",
-                        "required": False
+                        "default": ""
                     },
                     "max_results": {
                         "type": "integer",


### PR DESCRIPTION
Fixes #53

## Summary

- The `query` property in `query_gmail_emails` tool definition has `"required": false` at the property level, which is not valid JSON Schema (draft 2020-12)
- In JSON Schema, `required` must be an array at the object level — `"required": false` is an OpenAPI concept, not JSON Schema
- This causes Claude API to reject **all** tool calls with: `tools.9.custom.input_schema: JSON schema is invalid`
- Replaced with `"default": ""` to indicate the field is optional

## Test plan

- [x] Verified the fix resolves the schema validation error when used with Claude Code