### PR TITLE
fix: add text/html fallback for multipart email body extraction

### DIFF
--- a/src/mcp_gsuite/gmail.py
+++ b/src/mcp_gsuite/gmail.py
@@ -109,8 +109,15 @@ class GmailService():
                         data = part.get('body', {}).get('data')
                         if data:
                             return base64.urlsafe_b64decode(data).decode('utf-8')
-                
-                # If no direct text/plain, recursively check nested multipart structures
+
+                # Fallback to text/html if no text/plain with content
+                for part in parts:
+                    if part.get('mimeType') == 'text/html':
+                        data = part.get('body', {}).get('data')
+                        if data:
+                            return base64.urlsafe_b64decode(data).decode('utf-8')
+
+                # If no direct text part, recursively check nested multipart structures
                 for part in parts:
                     if part.get('mimeType', '').startswith('multipart/'):
                         nested_body = self._extract_body(part)


### PR DESCRIPTION
## Summary

- When a `multipart/alternative` email has an empty `text/plain` part and only contains content in `text/html`, `_extract_body()` returns `None` because it only searches for `text/plain` parts within multipart messages.
- This adds a `text/html` fallback loop after the `text/plain` search within the multipart handling block, consistent with the single-part `text/html` handling added in #31.

## Context

Some senders (e.g. bank notification emails) send `multipart/alternative` emails where the `text/plain` part is empty and all content is in `text/html`. PR #31 fixed this for single-part emails but the multipart case was missed.

## Test plan

- [x] Tested with a real `multipart/alternative` email that has an empty `text/plain` part — body is now correctly extracted from the `text/html` part.
- [x] Emails with valid `text/plain` content still return `text/plain` (preferred).
- [x] Nested multipart structures still work via recursion.